### PR TITLE
[201911][swss] Add feature to determine port status by tracking debug drop counters.

### DIFF
--- a/orchagent/countercheckorch.h
+++ b/orchagent/countercheckorch.h
@@ -1,6 +1,8 @@
 #ifndef COUNTERCHECK_ORCH_H
 #define COUNTERCHECK_ORCH_H
 
+#include "debugcounterorch.h"
+
 #include "orch.h"
 #include "port.h"
 #include "timer.h"
@@ -23,6 +25,8 @@ public:
     virtual void doTask(Consumer &consumer) {}
     void addPort(const swss::Port& port);
     void removePort(const swss::Port& port);
+    void addDebugCounter(const std::string counter_name, const std::string counter_type, int threshold, int timeout);
+    int removeDebugCounter(const std::string counter_name);
 
 private:
     CounterCheckOrch(swss::DBConnector *db, std::vector<std::string> &tableNames);
@@ -31,12 +35,34 @@ private:
     PfcFrameCounters getPfcFrameCounters(sai_object_id_t portId);
     void mcCounterCheck();
     void pfcFrameCounterCheck();
+    void debugCounterCheck();
+
+    void addPortAlarm(const std::string dev_name, const std::string counter_name);
+    void removePortAlarm(const std::string dev_name, const std::string counter_name);
+
+    void processPortCounters(const std::string counter_name, const std::string stat_name, const std::string dev_name, const std::string oid);
+    std::vector<swss::FieldValueTuple> getDevices(std::string counter_type);
+    std::string getStatName(const std::string counter_name, const std::string counter_type);
+    
+    int interval_count;
+
+    std::map<std::string, std::string> m_stdPortMap;
 
     std::map<sai_object_id_t, QueueMcCounters> m_mcCountersMap;
     std::map<sai_object_id_t, PfcFrameCounters> m_pfcFrameCountersMap;
 
+    // Should probably typdedef this for clarity
+    std::map<std::string, std::tuple<std::string, int, int, std::map<std::string, long int>, std::map<std::string, int>>> debugCounterMap;
+
     std::shared_ptr<swss::DBConnector> m_countersDb = nullptr;
+    std::shared_ptr<swss::DBConnector> m_asicDb = nullptr;
+    std::shared_ptr<swss::DBConnector> m_applDb = nullptr;
     std::shared_ptr<swss::Table> m_countersTable = nullptr;
+    std::shared_ptr<swss::Table> m_countersSwitchStatTable = nullptr;
+    std::shared_ptr<swss::Table> m_countersPortStatTable = nullptr;
+    std::shared_ptr<swss::Table> m_countersPortNameTable = nullptr;
+    std::shared_ptr<swss::Table> m_asicStateTable = nullptr;
+    std::shared_ptr<swss::Table> m_applPortTable = nullptr;
 };
 
 #endif

--- a/orchagent/debug_counter/debug_counter.cpp
+++ b/orchagent/debug_counter/debug_counter.cpp
@@ -26,6 +26,8 @@ const unordered_set<string> DebugCounter::supported_debug_counter_attributes =
 {
     COUNTER_ALIAS,
     COUNTER_TYPE,
+    COUNTER_THRESHOLD,
+    COUNTER_TIMEOUT,
     COUNTER_DESCRIPTION,
     COUNTER_GROUP
 };

--- a/orchagent/debug_counter/debug_counter.h
+++ b/orchagent/debug_counter/debug_counter.h
@@ -12,6 +12,8 @@ extern "C" {
 // Supported debug counter attributes.
 #define COUNTER_ALIAS       "alias"
 #define COUNTER_TYPE        "type"
+#define COUNTER_THRESHOLD   "threshold"
+#define COUNTER_TIMEOUT     "timeout"
 #define COUNTER_DESCRIPTION "desc"
 #define COUNTER_GROUP       "group"
 

--- a/orchagent/debugcounterorch.h
+++ b/orchagent/debugcounterorch.h
@@ -17,6 +17,13 @@ extern "C" {
 
 #define DEBUG_COUNTER_FLEX_COUNTER_GROUP "DEBUG_COUNTER"
 
+// Attributes form CONFIG_DB for the debug counters
+struct counter_attributes {
+    std::string type;
+    int threshold;
+    int timeout;
+};
+
 // DebugCounterOrch is an orchestrator for managing debug counters. It handles
 // the creation, deletion, and modification of debug counters.
 class DebugCounterOrch: public Orch
@@ -38,7 +45,7 @@ private:
     task_process_status removeDropReason(const std::string& counter_name, const std::string& drop_reason);
 
     // Free Table Management Functions
-    void addFreeCounter(const std::string& counter_name, const std::string& counter_type);
+    void addFreeCounter(const std::string& counter_name, counter_attributes* attr_struct);
     void deleteFreeCounter(const std::string& counter_name);
     void addFreeDropReason(const std::string& counter_name, const std::string& drop_reason);
     void deleteFreeDropReason(const std::string& counter_name, const std::string& drop_reason);
@@ -54,11 +61,11 @@ private:
             const std::string& counter_stat);
 
     // Debug Counter Initialization Helper Functions
-    std::string getDebugCounterType(
+    counter_attributes* getDebugCounterAttributes(
             const std::vector<swss::FieldValueTuple>& values) const noexcept(false);
     void createDropCounter(
             const std::string& counter_name,
-            const std::string& counter_type,
+            counter_attributes* attr_struct,
             const std::unordered_set<std::string>& drop_reasons) noexcept(false);
 
     // Debug Counter Configuration Helper Functions
@@ -84,12 +91,13 @@ private:
     FlexCounterStatManager flex_counter_manager;
 
     std::unordered_map<std::string, std::unique_ptr<DebugCounter>> debug_counters;
+    std::unordered_map<std::string, counter_attributes*> debug_attributes;
 
     // free_drop_counters are drop counters that have been created by a user
     // that do not have any drop reasons associated with them yet. Because
     // we cannot create a drop counter without any drop reasons, we keep track
     // of these counters in this table.
-    std::unordered_map<std::string, std::string> free_drop_counters;
+    std::unordered_map<std::string, counter_attributes*> free_drop_counters;
 
     // free_drop_reasons are drop reasons that have been added by a user
     // that do not have a counter associated with them yet. Because we


### PR DESCRIPTION
Add timeout and threshold feature to existing dropcounter feature. When timeout is hit the dropcounter is reset.
When the count exceeds the threshold an alarm is raised through APPL_DB visible via `show interfaces status` with
the name of the offending drop counter.
