### PR TITLE
[orchagent][ports] Add port reference increment / decrement to lag member add / remove flows

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4806,6 +4806,8 @@ bool PortsOrch::addLagMember(Port &lag, Port &port, bool enableForwarding)
         }
     }
 
+    increasePortRefCount(port.m_alias);
+
     LagMemberUpdate update = { lag, port, true };
     notify(SUBJECT_TYPE_LAG_MEMBER_CHANGE, static_cast<void *>(&update));
 
@@ -4851,6 +4853,9 @@ bool PortsOrch::removeLagMember(Port &lag, Port &port)
             return false;
         }
     }
+
+    decreasePortRefCount(port.m_alias);
+
     LagMemberUpdate update = { lag, port, false };
     notify(SUBJECT_TYPE_LAG_MEMBER_CHANGE, static_cast<void *>(&update));
 

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3221,11 +3221,11 @@ void PortsOrch::doPortTask(Consumer &consumer)
                 {
                     throw runtime_error("Remove hostif for the port failed");
                 }
+		m_portList[alias].m_hif_id = SAI_NULL_OBJECT_ID;
 
                 Port p;
                 if (getPort(port_id, p))
                 {
-		    p.m_hif_id = null;
                     PortUpdate update = {p, false};
                     notify(SUBJECT_TYPE_PORT_CHANGE, static_cast<void *>(&update));
                 }
@@ -4844,7 +4844,7 @@ bool PortsOrch::removeLagMember(Port &lag, Port &port)
 
     if (lag.m_bridge_port_id > 0)
     {
-        if (port.m_hif_id && !setHostIntfsStripTag(port, SAI_HOSTIF_VLAN_TAG_STRIP))
+        if (port.m_hif_id != SAI_NULL_OBJECT_ID && !setHostIntfsStripTag(port, SAI_HOSTIF_VLAN_TAG_STRIP))
         {
             SWSS_LOG_ERROR("Failed to set %s for hostif of port %s which is leaving LAG %s",
                     hostif_vlan_tag[SAI_HOSTIF_VLAN_TAG_STRIP], port.m_alias.c_str(), lag.m_alias.c_str());

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3221,7 +3221,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
                 {
                     throw runtime_error("Remove hostif for the port failed");
                 }
-		m_portList[alias].m_hif_id = SAI_NULL_OBJECT_ID;
+                m_portList[alias].m_hif_id = SAI_NULL_OBJECT_ID;
 
                 Port p;
                 if (getPort(port_id, p))

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3225,6 +3225,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
                 Port p;
                 if (getPort(port_id, p))
                 {
+		    p.m_hif_id = null;
                     PortUpdate update = {p, false};
                     notify(SUBJECT_TYPE_PORT_CHANGE, static_cast<void *>(&update));
                 }
@@ -4843,16 +4844,7 @@ bool PortsOrch::removeLagMember(Port &lag, Port &port)
 
     if (lag.m_bridge_port_id > 0)
     {
-        bool hostif_exists = true;
-        sai_attribute_t attr;
-        attr.id = SAI_HOSTIF_ATTR_START;
-
-        sai_status_t status = sai_hostif_api->get_hostif_attribute(port.m_hif_id, 1, &attr);
-        if (status != SAI_STATUS_SUCCESS)
-        {
-	    hostif_exists = false;
-        }
-        if (hostif_exists && !setHostIntfsStripTag(port, SAI_HOSTIF_VLAN_TAG_STRIP))
+        if (port.m_hif_id && !setHostIntfsStripTag(port, SAI_HOSTIF_VLAN_TAG_STRIP))
         {
             SWSS_LOG_ERROR("Failed to set %s for hostif of port %s which is leaving LAG %s",
                     hostif_vlan_tag[SAI_HOSTIF_VLAN_TAG_STRIP], port.m_alias.c_str(), lag.m_alias.c_str());

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3221,7 +3221,6 @@ void PortsOrch::doPortTask(Consumer &consumer)
                 {
                     throw runtime_error("Remove hostif for the port failed");
                 }
-                m_portList[alias].m_hif_id = SAI_NULL_OBJECT_ID;
 
                 Port p;
                 if (getPort(port_id, p))
@@ -4846,7 +4845,7 @@ bool PortsOrch::removeLagMember(Port &lag, Port &port)
 
     if (lag.m_bridge_port_id > 0)
     {
-        if (port.m_hif_id != SAI_NULL_OBJECT_ID && !setHostIntfsStripTag(port, SAI_HOSTIF_VLAN_TAG_STRIP))
+        if (!setHostIntfsStripTag(port, SAI_HOSTIF_VLAN_TAG_STRIP))
         {
             SWSS_LOG_ERROR("Failed to set %s for hostif of port %s which is leaving LAG %s",
                     hostif_vlan_tag[SAI_HOSTIF_VLAN_TAG_STRIP], port.m_alias.c_str(), lag.m_alias.c_str());

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4843,7 +4843,16 @@ bool PortsOrch::removeLagMember(Port &lag, Port &port)
 
     if (lag.m_bridge_port_id > 0)
     {
-        if (!setHostIntfsStripTag(port, SAI_HOSTIF_VLAN_TAG_STRIP))
+        bool hostif_exists = true;
+        sai_attribute_t attr;
+        attr.id = SAI_HOSTIF_ATTR_START;
+
+        sai_status_t status = sai_hostif_api->get_hostif_attribute(port.m_hif_id, 1, &attr);
+        if (status != SAI_STATUS_SUCCESS)
+        {
+	    hostif_exists = false;
+        }
+        if (hostif_exists && !setHostIntfsStripTag(port, SAI_HOSTIF_VLAN_TAG_STRIP))
         {
             SWSS_LOG_ERROR("Failed to set %s for hostif of port %s which is leaving LAG %s",
                     hostif_vlan_tag[SAI_HOSTIF_VLAN_TAG_STRIP], port.m_alias.c_str(), lag.m_alias.c_str());


### PR DESCRIPTION
**What I did**

Added code to increment the port reference counter on the creation of a lag membership that involves that port. Also added code to decrement the counter on the removal of that lag membership as well. This prevents the port from being removed before the lag membership is. 

**Why I did it**

In some cases (particularly in the dynamic port breakout flow) if a LAG membership was removed at the same time a port was removed the host interface would be deleted before the membership removal was processed. This would result in orchagent attempting to strip the VLAN tag from a non-existent host interface causing a crash. 

**How I verified it**

Tested previously broken flow on a MSN2700

```
root@r-panther-23:/home/admin# config portchannel add PortChannel0004
root@r-panther-23:/home/admin# config portchannel member add PortChannel0004 Ethernet16
root@r-panther-23:/home/admin# config vlan add 2147
root@r-panther-23:/home/admin# config vlan member add --untagged 2147 PortChannel0004
root@r-panther-23:/home/admin# config int ip add Vlan2147 10.0.0.2/24
root@r-panther-23:/home/admin# config int break Ethernet16 2x50G[40G,25G,10G] -f -y

Running Breakout Mode : 1x100G[50G,40G,25G,10G]
Target Breakout Mode : 2x50G[40G,25G,10G]

Ports to be deleted :
 {
    "Ethernet16": "100000"
}
Ports to be added :
 {
    "Ethernet16": "50000",
    "Ethernet18": "50000"
}

After running Logic to limit the impact

Final list of ports to be deleted :
 {
    "Ethernet16": "100000"
}
Final list of ports to be added :
 {
    "Ethernet16": "50000",
    "Ethernet18": "50000"
}
Note: Below table(s) have no YANG models:
FEATURE, KDUMP, SNMP, SNMP_COMMUNITY, XCVRD_LOG,
Below Config can not be verified, It may cause harm to the system
 {}
Do you wish to Continue? [y/N]: y
Breakout process got successfully completed.
Please note loaded setting will be lost after system reboot. To preserve setting, run `config save`.
root@r-panther-23:/home/admin#
```
