### PR TITLE
[crmorch] Prevent exceededLogCounter from resetting when low and high values are equal

### DIFF
--- a/orchagent/crmorch.cpp
+++ b/orchagent/crmorch.cpp
@@ -768,7 +768,7 @@ void CrmOrch::checkCrmThresholds()
 
                 res.exceededLogCounter++;
             }
-            else if ((utilization <= res.lowThreshold) && (res.exceededLogCounter > 0))
+            else if ((utilization < res.lowThreshold) && (res.exceededLogCounter > 0))
             {
                 SWSS_LOG_WARN("%s THRESHOLD_CLEAR for %s %u%% Used count %u free count %u",
                               res.name.c_str(), threshType.c_str(), percentageUtil, cnt.usedCounter, cnt.availableCounter);

--- a/orchagent/crmorch.cpp
+++ b/orchagent/crmorch.cpp
@@ -768,7 +768,7 @@ void CrmOrch::checkCrmThresholds()
 
                 res.exceededLogCounter++;
             }
-            else if ((utilization < res.lowThreshold) && (res.exceededLogCounter > 0))
+            else if ((utilization <= res.lowThreshold) && (res.exceededLogCounter > 0) && (res.highThreshold != res.lowThreshold))
             {
                 SWSS_LOG_WARN("%s THRESHOLD_CLEAR for %s %u%% Used count %u free count %u",
                               res.name.c_str(), threshType.c_str(), percentageUtil, cnt.usedCounter, cnt.availableCounter);


### PR DESCRIPTION
**What I did**

Made the if / else if condition in the CRM logic mutually exclusive so that you cannot enter a state where the resource utilization does not change but the counter is constantly reset and the log is spammed with CRM messages. 

**Why I did it**

If a user sets the "low" value and the "high" value equal to each other (a condition which is possible to be manually configured using the CLI or CONFIG_DB) the log will immediately get spammed with CRM messages because the counter will almost instantly reset even if the utilization does not change because the condition in the `if` statement and the condition in the `else if` statement can be true simultaneously. 

**How I verified it**

Manually tested by manually configuring a CRM resource `high` and `low` threshold to be equal and verifying that the number of error logs seen does not exceed the max value. 

